### PR TITLE
Fixed links in index.html and _layouts/body.html

### DIFF
--- a/_layouts/body.html
+++ b/_layouts/body.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <header>
-  <h1><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
+  <h1><a href="{{ site.domain }}{{ site.baseurl }}">{{ site.name }}</a></h1>
 </header>
 
 {{ content }}

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Page Title
 <h1>blog posts</h1>
 <ul class="posts">
 {% for post in posts %}
-  <li>{{ post.date | date_to_string }} &raquo; <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></li>
+  <li>{{ post.date | date_to_string }} &raquo; <a href="{{ site.domain }}{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></li>
 {% endfor %}
 </ul>
 


### PR DESCRIPTION
Added `{{ site.domain }}` before `{{ site.baseurl }}`.

As it was, the links served by Jekyll were broken. This makes it so that they include the domain name (and work on localhost - in my case, I set the `domain:` in `_config.yaml` to `http://localhost:4000`).
